### PR TITLE
Add support for grouping digits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,7 +537,8 @@ fn digits_to_a(sign: bool, mut digits: Vec<u8>, mut e: i32, config: FmtFloatConf
         if let Some((group_size, separator)) = config.group_digits {
             
             if (e - curr) % i32::from(group_size) == 0 // we are on the group separator
-            && curr != 0 // don't add a separator at the start
+            && curr != 0 // don't add a separator at the start of the number
+            && curr != e // or just after the radix point
             && e > 0 // group_digits is only for positive numbers
             {
                 as_str.push(separator);
@@ -550,10 +551,8 @@ fn digits_to_a(sign: bool, mut digits: Vec<u8>, mut e: i32, config: FmtFloatConf
     while e > 0 && curr < e {
         // add the separator between groups of digits if configured
         if let Some((group_size, separator)) = config.group_digits {
-            println!("e: {}, curr: {}", e, curr);
-            if (e - curr) % i32::from(group_size) == 0 // we are on the group separator
-            && curr != 0 // don't add a separator at the start
-            {
+            // we are on the group separator
+            if (e - curr) % i32::from(group_size) == 0 {
                 as_str.push(separator);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,6 +279,16 @@ impl FmtFloatConfig {
         self.radix_point = val;
         self
     }
+
+    /// Group digits together in groups of `group_by` digits,
+    /// and separate them with `separator`
+    /// .i.e: with Some(3,' ')
+    /// 10000 -> 10 000
+    pub const fn group_digits(mut self, group_by: u8, separator: char) -> Self {
+        self.group_digits = Some((group_by, separator));
+        self
+    }
+    
 }
 
 const fn digit_to_u8(val: u8) -> u8 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,11 +529,16 @@ fn digits_to_a(sign: bool, mut digits: Vec<u8>, mut e: i32, config: FmtFloatConf
             as_str.push('0');
         }
     }
-    for digit in digits {
+    for (i, digit) in digits.iter().enumerate() {
         if e > 0 && curr == e {
             as_str.push(config.radix_point);
         }
-        as_str.push(digit as char);
+        if let Some((group_size, separator)) = config.group_digits {
+            if (digits.len() - i) % usize::from(group_size) == 0 {
+                as_str.push(separator);
+            }
+        }
+        as_str.push(*digit as char);
         curr += 1;
     }
     let is_integer = curr <= e;
@@ -921,7 +926,8 @@ mod tests {
             .upper_e_break(10)
             .add_point_zero(false)
             .group_digits(3, ' ');
-        assert_eq!(dtoa(10000.0, config), "10 000");
+        assert_eq!(dtoa(12345678.0, config), "12 345 678");
+        assert_eq!(dtoa(1234567.0, config), "1 234 567");
     }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,8 +538,7 @@ fn digits_to_a(sign: bool, mut digits: Vec<u8>, mut e: i32, config: FmtFloatConf
             
             if (e - curr) % i32::from(group_size) == 0 // we are on the group separator
             && curr != 0 // don't add a separator at the start of the number
-            && curr < e // or just after the radix point
-            && e > 0 // group_digits is only for positive numbers
+            && curr < e // or after the radix point
             {
                 as_str.push(separator);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@ macro_rules! hit {
 macro_rules! hit {
     ($ident:ident) => {{
         extern "C" {
-            #[no_mangle]
             static $ident: $crate::__rt::AtomicUsize;
         }
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,9 @@ pub struct FmtFloatConfig {
     pub max_width: Option<u8>,
     /// The seperator between the integer and non-integer part
     pub radix_point: char,
+    /// Group digits together, and separate them with `char`
+    /// .i.e: With Some(3,' '): 10000 -> 10 000
+    pub group_digits: Option<(u8, char)>,
 }
 
 impl FmtFloatConfig {
@@ -151,6 +154,7 @@ impl FmtFloatConfig {
             add_point_zero: true,
             max_width: None,
             radix_point: '.',
+            group_digits: None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,13 +402,13 @@ fn digits_to_a(sign: bool, mut digits: Vec<u8>, mut e: i32, config: FmtFloatConf
         let max_width = if sign { max_width - 1 } else { max_width };
         // Is it impossible to represent the value without e notation?
         if e > 0 && e + if config.add_point_zero { 2 } else { 0 } > max_width as i32 {
-            hit!(e_width_case_a);
+            hit!(E_WIDTH_CASE_A);
             use_e_notation = true;
         } else if -e + 3 > max_width as i32 {
-            hit!(e_width_case_b);
+            hit!(E_WIDTH_CASE_B);
             use_e_notation = true;
         } else if !use_e_notation {
-            hit!(e_width_case_c);
+            hit!(E_WIDTH_CASE_C);
             // Otherwise, prepare to not use e notation
             let is_integer = e > digits.len() as i32;
             let extra_length = if config.add_point_zero && is_integer {
@@ -628,7 +628,7 @@ mod tests {
 
     #[test]
     fn test_widths() {
-        check!(test_widths_internal);
+        check!(TEST_WIDTHS_INTERNAL);
         // Test random floats with several configurations, and
         // make sure that .max_width(_) does its job
         let mut rng = rand::thread_rng();
@@ -660,7 +660,7 @@ mod tests {
                 );
                 if as_string.chars().nth(0) == Some('#') {
                     assert!(width <= 6, "Found example of a too-wide float: {}", val);
-                    hit!(test_widths_internal);
+                    hit!(TEST_WIDTHS_INTERNAL);
                 }
             }
         }
@@ -857,9 +857,9 @@ mod tests {
 
     #[test]
     fn test_max_width_specifics() {
-        check!(e_width_case_a);
-        check!(e_width_case_b);
-        check!(e_width_case_c);
+        check!(E_WIDTH_CASE_A);
+        check!(E_WIDTH_CASE_B);
+        check!(E_WIDTH_CASE_C);
         let config = FmtFloatConfig::default().max_width(6).force_no_e_notation();
         assert_eq!(dtoa(123.4533, config), "123.45");
         assert_eq!(dtoa(0.00324, config), "0.0032");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ mod __rt {
             let value_on_exit = self.mark.load(Ordering::Relaxed);
             assert!(
                 value_on_exit > self.value_on_entry,
-                format!("mark was not hit: {}", self.name)
+                "mark was not hit: {}", self.name
             )
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -914,4 +914,14 @@ mod tests {
 
         assert_eq!(dtoa(0., config), "0");
     }
+
+    #[test]
+    fn test_group_digits() {
+        let config = FmtFloatConfig::default()
+            .upper_e_break(10)
+            .add_point_zero(false)
+            .group_digits(3, ' ');
+        assert_eq!(dtoa(10000.0, config), "10 000");
+    }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,7 +538,7 @@ fn digits_to_a(sign: bool, mut digits: Vec<u8>, mut e: i32, config: FmtFloatConf
             
             if (e - curr) % i32::from(group_size) == 0 // we are on the group separator
             && curr != 0 // don't add a separator at the start of the number
-            && curr != e // or just after the radix point
+            && curr < e // or just after the radix point
             && e > 0 // group_digits is only for positive numbers
             {
                 as_str.push(separator);
@@ -938,14 +938,17 @@ mod tests {
     fn test_group_digits() {
         let config = FmtFloatConfig::default()
             .upper_e_break(10)
+            .lower_e_break(-10)
             .add_point_zero(false)
             .group_digits(3, ' ');
         assert_eq!(dtoa(12345678.0, config), "12 345 678");
         assert_eq!(dtoa(1234567.0, config), "1 234 567");
         assert_eq!(dtoa(123456.0, config), "123 456");
         assert_eq!(dtoa(100000.0, config), "100 000");
+        assert_eq!(dtoa(0.00000001, config), "0.00000001");
         assert_eq!(dtoa(0.1234568, config), "0.1234568");
         assert_eq!(dtoa(12345.68, config), "12 345.68");
+        assert_eq!(dtoa(12.345689, config), "12.345689");
     }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,20 +529,35 @@ fn digits_to_a(sign: bool, mut digits: Vec<u8>, mut e: i32, config: FmtFloatConf
             as_str.push('0');
         }
     }
-    for (i, digit) in digits.iter().enumerate() {
+    for digit in digits {
         if e > 0 && curr == e {
             as_str.push(config.radix_point);
         }
+        // add the separator between groups of digits if configured
         if let Some((group_size, separator)) = config.group_digits {
-            if (digits.len() - i) % usize::from(group_size) == 0 {
+            
+            if (e - curr) % i32::from(group_size) == 0 // we are on the group separator
+            && curr != 0 // don't add a separator at the start
+            && e > 0 // group_digits is only for positive numbers
+            {
                 as_str.push(separator);
             }
         }
-        as_str.push(*digit as char);
+        as_str.push(digit as char);
         curr += 1;
     }
     let is_integer = curr <= e;
     while e > 0 && curr < e {
+        // add the separator between groups of digits if configured
+        if let Some((group_size, separator)) = config.group_digits {
+            println!("e: {}, curr: {}", e, curr);
+            if (e - curr) % i32::from(group_size) == 0 // we are on the group separator
+            && curr != 0 // don't add a separator at the start
+            {
+                as_str.push(separator);
+            }
+        }
+
         as_str.push('0');
         curr += 1;
     }
@@ -550,7 +565,7 @@ fn digits_to_a(sign: bool, mut digits: Vec<u8>, mut e: i32, config: FmtFloatConf
         as_str.push(config.radix_point);
         as_str.push('0');
     }
-
+    
     as_str
 }
 
@@ -928,6 +943,10 @@ mod tests {
             .group_digits(3, ' ');
         assert_eq!(dtoa(12345678.0, config), "12 345 678");
         assert_eq!(dtoa(1234567.0, config), "1 234 567");
+        assert_eq!(dtoa(123456.0, config), "123 456");
+        assert_eq!(dtoa(100000.0, config), "100 000");
+        assert_eq!(dtoa(0.1234568, config), "0.1234568");
+        assert_eq!(dtoa(12345.68, config), "12 345.68");
     }
 
 }


### PR DESCRIPTION
Hello,

I am really happy to have found you crate that does exactly what I need. Thanks !

I have added a feature to group digits (issue #2).

It only works for digits before the radix point.
I plan to do something similar for decimal after the radix point.

The first 2 commits fix compiler warning.